### PR TITLE
Add md5 column to image archive DB

### DIFF
--- a/lib/db_manager.py
+++ b/lib/db_manager.py
@@ -25,6 +25,7 @@ backends.
 
 """
 
+import logging
 import sqlite3
 import datetime
 import psycopg2
@@ -62,13 +63,14 @@ class DbManager(object):
         """
         self.dbType = None
         if sqliteFile:
+            logging.warning('using sqlite %s', sqliteFile)
             self.dbType = 'sqlite'
             self.conn = sqlite3.connect(sqliteFile)
             self.conn.row_factory = _dict_factory
         elif psqlHost:
+            logging.warning('using postgres %s', psqlHost)
             self.dbType = 'psql'
             self.conn = psycopg2.connect(host=psqlHost, database=psqlDb, user=psqlUser, password=psqlPasswd)
-        print('DbType', self.dbType, sqliteFile, psqlHost)
 
         sources_schema = [
             ('name', 'TEXT'),
@@ -173,6 +175,7 @@ class DbManager(object):
             ('Pan', 'REAL'),
             ('Tilt', 'REAL'),
             ('Zoom', 'REAL'),
+            ('md5', 'TEXT'),
         ]
 
         self.tables = {

--- a/lib/img_archive.py
+++ b/lib/img_archive.py
@@ -595,7 +595,7 @@ def diffImages(imgA, imgB):
     return Image.merge('RGB', bandsImgOut)
 
 
-def addImageToArchiveDb(dbManager, cameraID, timestamp, storageID, fileID, pan, tilt, zoom):
+def addImageToArchiveDb(dbManager, cameraID, timestamp, storageID, fileID, pan, tilt, zoom, md5):
     """Add the given image information to the image archive DB
 
     Args:
@@ -607,6 +607,7 @@ def addImageToArchiveDb(dbManager, cameraID, timestamp, storageID, fileID, pan, 
         pan (float): Pan value for PTZ cameras
         tilt (float): Tilt value for PTZ cameras
         zoom (float): Zoom value for PTZ cameras
+        md5 (str): md5 hash of the image data
     """
     dbRow = {
         'CameraName': cameraID,
@@ -615,7 +616,8 @@ def addImageToArchiveDb(dbManager, cameraID, timestamp, storageID, fileID, pan, 
         'FileID': fileID,
         'Pan': pan,
         'Tilt': tilt,
-        'Zoom': zoom
+        'Zoom': zoom,
+        'md5': md5
     }
     dbManager.add_data('archive', dbRow)
 

--- a/smoke-classifier/detect_fire.py
+++ b/smoke-classifier/detect_fire.py
@@ -599,13 +599,9 @@ def main():
     # commenting out the print below to reduce showing secrets in settings
     # print('Settings:', list(map(lambda a: (a,getattr(settings,a)), filter(lambda a: not a.startswith('__'), dir(settings)))))
     googleServices = goog_helper.getGoogleServices(settings, args)
-    if settings.db_file:
-        logging.warning('using sqlite %s', settings.db_file)
-        dbManager = db_manager.DbManager(sqliteFile=settings.db_file)
-    else:
-        logging.warning('using postgres %s', settings.psqlHost)
-        dbManager = db_manager.DbManager(psqlHost=settings.psqlHost, psqlDb=settings.psqlDb,
-                                        psqlUser=settings.psqlUser, psqlPasswd=settings.psqlPasswd)
+    dbManager = db_manager.DbManager(sqliteFile=settings.db_file,
+                                    psqlHost=settings.psqlHost, psqlDb=settings.psqlDb,
+                                    psqlUser=settings.psqlUser, psqlPasswd=settings.psqlPasswd)
     cameras = dbManager.get_sources(activeOnly=True, restrictType=args.restrictType)
 
     deferredImages = []


### PR DESCRIPTION
The image API sometimes returns the same image as before, so add
md5 values to DB to detect such conditions.  The data will be
used in future changes.
Also, some code cleanup and refactoring around db selection