### PR TITLE
bcc email alerts from notifications db

### DIFF
--- a/lib/email_helper.py
+++ b/lib/email_helper.py
@@ -26,22 +26,22 @@ from email import encoders
 import pathlib
 
 
-def send_email(fromAccount, toaddr, bcc, subject, body, attachments=[]):
+def send_email(fromAccount, visibleToAddrs, realToAddrs, subject, body, attachments=[]):
     """Send an email using credentials of fromAccount to given recepients
 
     Args:
         fromAccount (tuple): tuple of (email, password) of from account
-        toaddr (str or list): email address(es) to send email to as string e.g. 'joe@gmail.com'
-        bcc (str or list): email address(es) to bcc the email
+        visibleToAddrs (str or list): email address(es) that appear in "To"
+        realToAddrs (str or list): email address(es) to which email is actually sent to
         subject (str): subject of the email
         body (str): body of the email
         attachments (list): optional list of attachements files
     """
     (fromEmail, fromPass) = fromAccount
-    if isinstance(toaddr, str):
-        toaddr = [toaddr]
-    if isinstance(bcc, str):
-        bcc = [bcc]
+    if isinstance(visibleToAddrs, str):
+        visibleToAddrs = [visibleToAddrs]
+    if isinstance(realToAddrs, str):
+        realToAddrs = [realToAddrs]
 
     parts=[]
     for filePath in attachments:
@@ -58,7 +58,7 @@ def send_email(fromAccount, toaddr, bcc, subject, body, attachments=[]):
     #setup message headers
     msg = MIMEMultipart()
     msg['From'] = fromEmail
-    msg['To'] = ', '.join(list(toaddr))
+    msg['To'] = ', '.join(list(visibleToAddrs))
     msg['Subject'] = subject
     msg.attach(MIMEText(body, 'plain'))
     for part in parts:
@@ -90,13 +90,12 @@ def send_email(fromAccount, toaddr, bcc, subject, body, attachments=[]):
         return
 
     try:
-        server.sendmail(fromEmail, toaddr + bcc, text)
+        server.sendmail(fromEmail, realToAddrs, text)
     except Exception as e:
         print("Sending Email Failed", e)
         # print("From Addess ", fromEmail)
-        # print("To Address", toaddr)
+        # print("To Address", realToAddrs)
         # print("Text", text)
-        # server.sendmail(fromEmail, toaddr, text)
         return
         
     try:

--- a/sample_settings.py
+++ b/sample_settings.py
@@ -47,7 +47,6 @@ camerasSheetRange = 'Code Name Archive Mapping!A1:G1000'
 
 fuegoEmail = 'fuego.response@gmail.com'
 fuegoPasswd = 'do not put real password in files in open source git repo'
-detectionsEmail = 'fuego.detect@gmail.com'
 
 psqlHost = '127.0.0.1'
 psqlDb = 'postgres'

--- a/smoke-classifier/detect_fire.py
+++ b/smoke-classifier/detect_fire.py
@@ -456,11 +456,11 @@ def emailFireNotification(dbManager, camera, imgPath, annotatedFile, driveFileID
         driveBody = driveTempl % driveFileID
         body += driveBody
 
-    # emails are sent from settings.fuegoEmail to settings.detectionsEmail with bcc to everyone
-    # with active emails in notifications SQL table
+    # emails are sent from settings.fuegoEmail and bcc to everyone with active emails in notifications SQL table
     dbResult = dbManager.getNotifications(filterActiveEmail = True)
     emails = [x['email'] for x in dbResult]
-    email_helper.send_email(fromAccount, settings.detectionsEmail, emails, subject, body, [imgPath, annotatedFile])
+    if len(emails) > 0:
+        email_helper.send_email(fromAccount, settings.fuegoEmail, emails, subject, body, [imgPath, annotatedFile])
 
 
 def smsFireNotification(dbManager, camera):


### PR DESCRIPTION
Removed the default detectionsEmail value from settings.  All emails
are now sent from fuegoEmail and appear to be sent to the same
fuegoEmail.  The real addresses are all bcc'd.