### PR TITLE
Use gmail API vs. SMTP to send emails

### DIFF
--- a/lib/email_helper.py
+++ b/lib/email_helper.py
@@ -24,10 +24,66 @@ from email.mime.text import MIMEText
 from email.mime.base import MIMEBase
 from email import encoders
 import pathlib
+import logging
+import base64
 
 
-def send_email(fromAccount, visibleToAddrs, realToAddrs, subject, body, attachments=[]):
-    """Send an email using credentials of fromAccount to given recepients
+def addAttachments(msg, attachments):
+    """Add given attachements to the given email message as MIME parts
+
+    Args:
+        msg: MIME email message
+        attachments (list): list of attachements files
+    """
+    for filePath in attachments:
+        #convert image to base64 encoding
+        attachFh = open(filePath, "rb")
+        part = MIMEBase('application', 'octet-stream')
+        part.set_payload((attachFh).read())
+        encoders.encode_base64(part)
+        filename = pathlib.PurePath(filePath).name
+        filename = filename.replace(';','_') # gmail considers ';' to mark end of filename
+        part.add_header('Content-Disposition', "attachment; filename= %s" % filename)
+        msg.attach(part)
+
+
+def sendEmail(mailService, toAddrs, bccAddrs, subject, body, attachments=[]):
+    """Send an email using GMail API and oauth2 service authentication
+       to given visible and bcc recepients with given subject,body, and attachments
+
+    Args:
+        mailService: Gmail service (from getGoogleServices()['mail'])
+        visibleToAddrs (str or list): email address(es) that appear in "To"
+        realToAddrs (str or list): email address(es) to which email is actually sent to
+        subject (str): subject of the email
+        body (str): body of the email
+        attachments (list): optional list of attachements files
+    """
+    if isinstance(toAddrs, str):
+        toAddrs = [toAddrs]
+    if isinstance(bccAddrs, str):
+        bccAddrs = [bccAddrs]
+
+    #setup message headers
+    msg = MIMEMultipart()
+    msg['From'] = 'me'
+    msg['To'] = ', '.join(list(toAddrs))
+    msg['Bcc'] = ', '.join(list(bccAddrs))
+    msg['Subject'] = subject
+    msg.attach(MIMEText(body, 'plain'))
+    addAttachments(msg, attachments)
+
+    #send the message
+    try:
+        body = {'raw': base64.urlsafe_b64encode(msg.as_string().encode('utf-8')).decode()}
+        result = mailService.users().messages().send(userId='me', body=body).execute()
+    except Exception as e:
+        logging.error('Error sending email. %s', str(e))
+
+
+def sendEmailSmtp(fromAccount, visibleToAddrs, realToAddrs, subject, body, attachments=[]):
+    """Send an email using SMTP API and user/password authentication
+       to given visible and bcc recepients with given subject,body, and attachments
 
     Args:
         fromAccount (tuple): tuple of (email, password) of from account
@@ -43,26 +99,13 @@ def send_email(fromAccount, visibleToAddrs, realToAddrs, subject, body, attachme
     if isinstance(realToAddrs, str):
         realToAddrs = [realToAddrs]
 
-    parts=[]
-    for filePath in attachments:
-        #convert image to base64 encoding 
-        attachFh = open(filePath, "rb")
-        part = MIMEBase('application', 'octet-stream')
-        part.set_payload((attachFh).read())
-        encoders.encode_base64(part)
-        filename = pathlib.PurePath(filePath).name
-        filename = filename.replace(';','_') # gmail considers ';' to mark end of filename
-        part.add_header('Content-Disposition', "attachment; filename= %s" % filename)
-        parts.append(part)
-
     #setup message headers
     msg = MIMEMultipart()
     msg['From'] = fromEmail
     msg['To'] = ', '.join(list(visibleToAddrs))
     msg['Subject'] = subject
     msg.attach(MIMEText(body, 'plain'))
-    for part in parts:
-        msg.attach(part)
+    addAttachments(msg, attachments)
 
     #send the message
     try:

--- a/lib/goog_helper.py
+++ b/lib/goog_helper.py
@@ -35,10 +35,12 @@ import collect_args
 import img_archive
 
 # If modifying these scopes, delete the file token.json.
+# TODO: This is getting too big.  We should ask for different subsets for each app
 SCOPES = [
     'https://www.googleapis.com/auth/drive',
     'https://www.googleapis.com/auth/spreadsheets',
     'https://www.googleapis.com/auth/devstorage.read_write',
+    'https://www.googleapis.com/auth/gmail.send',
     'profile' # to get id_token for gcf_ffmpeg
 ]
 
@@ -73,13 +75,11 @@ def getGoogleServices(settings, args):
         Dictionary with service tokens
     """
     creds = getCreds(settings, args)
-    driveService = build('drive', 'v3', http=creds.authorize(Http()))
-    sheetService = build('sheets', 'v4', http=creds.authorize(Http()))
-    storageService = build('storage', 'v1', http=creds.authorize(Http()))
     return {
-        'drive': driveService,
-        'sheet': sheetService,
-        'storage': storageService,
+        'drive': build('drive', 'v3', http=creds.authorize(Http())),
+        'sheet': build('sheets', 'v4', http=creds.authorize(Http())),
+        'storage': build('storage', 'v1', http=creds.authorize(Http())),
+        'mail': build('gmail', 'v1', http=creds.authorize(Http())),
         'creds': creds
     }
 

--- a/smoke-classifier/detect_fire.py
+++ b/smoke-classifier/detect_fire.py
@@ -451,7 +451,6 @@ def emailFireNotification(constants, cameraID, imgPath, annotatedFile, driveFile
         timestamp (int): time.time() value when image was taken
     """
     dbManager = constants['dbManager']
-    fromAccount = (settings.fuegoEmail, settings.fuegoPasswd)
     subject = 'Possible (%d%%) fire in camera %s' % (int(fireSegment['score']*100), cameraID)
     body = 'Please check the attached images for fire.'
     # commenting out links to google drive because they appear as extra attachments causing confusion
@@ -473,7 +472,7 @@ def emailFireNotification(constants, cameraID, imgPath, annotatedFile, driveFile
                                                     constants['camArchives'], cameraID, startTimeDT, endTimeDT, 1)
             oldImages = oldImages or []
             attachments = oldImages + [imgPath, annotatedFile]
-            email_helper.send_email(fromAccount, settings.fuegoEmail, emails, subject, body, attachments)
+            email_helper.sendEmail(constants['googleServices']['mail'], settings.fuegoEmail, emails, subject, body, attachments)
 
 
 def smsFireNotification(dbManager, cameraID):


### PR DESCRIPTION
Although this is less generic code, it lets us use Oauth2 authentication
that is lot more secure than user/password and avoids Google's
security false alerts.